### PR TITLE
Fix: fixed bugs and test cases to pass all tests

### DIFF
--- a/src/main/java/com/quantego/josqp/CSCMatrix.java
+++ b/src/main/java/com/quantego/josqp/CSCMatrix.java
@@ -8,9 +8,9 @@ public class CSCMatrix {
 	public final int m;
 	public int nz;
 	public int nzmax;
-	public final int[] Ap;
-    public final int[] Ai;
-    public final double[] Ax;
+	public int[] Ap;
+    public int[] Ai;
+    public double[] Ax;
 
     
 	public CSCMatrix(int m, int n, int nzmax, int[] ap, int[] ai, double[] ax) {
@@ -31,6 +31,21 @@ public class CSCMatrix {
 		this.Ap = new int[triplet ? nzmax : n+1];
 		this.Ai = new int[nzmax];
 		this.Ax = values ? new double[nzmax] : null;
+	}
+
+	/**
+	 * The new content must fit the existing size of the matrix.
+	 * @param nzmax
+	 * @param ap
+	 * @param ai
+	 * @param ax
+	 */
+	public void replaceContent(int nzmax, int[] ap, int[] ai, double[] ax) {
+		this.nz = ax.length;
+		this.nzmax = nzmax;
+		this.Ap = ap;
+		this.Ai = ai;
+		this.Ax = ax;
 	}
 	
 	public static CSCMatrix triplet_to_csc(CSCMatrix T, int[] TtoC) {

--- a/src/main/java/com/quantego/josqp/KKT.java
+++ b/src/main/java/com/quantego/josqp/KKT.java
@@ -91,7 +91,12 @@ class KKT {
 
 	  if (Pdiag_idx != null) {
 	    // Realloc Pdiag_idx so that it contains exactly *Pdiag_n diagonal elements
-		  Pdiag_idx[0] = new int[Pdiag_n[0]];
+		
+		int[] new_pdiag = new int[Pdiag_n[0]];
+		for(int ni=0;ni<Pdiag_n[0];ni++) new_pdiag[ni]=Pdiag_idx[0][ni];
+
+		  //Pdiag_idx[0] = new int[Pdiag_n[0]];
+		  Pdiag_idx[0] = new_pdiag;
 	  }
 
 

--- a/src/main/java/com/quantego/josqp/OSQP.java
+++ b/src/main/java/com/quantego/josqp/OSQP.java
@@ -410,7 +410,7 @@ public class OSQP {
 		if (!work.settings.warm_start) 
 			cold_start(work);  // If not warm start ->
 		                                                      // set x, z, y to zero
-		
+			
 		if (work.settings.verbose) {
 			print_setup_header(work);
 			print_header();
@@ -1102,7 +1102,7 @@ public class OSQP {
 
 		    for (i = 0; i < work.data.m; i++) {
 		      ineq_lhs += work.data.u[i] * Math.max(work.delta_y[i], 0) + 
-		                  work.data.l[i] * Math.max(work.delta_y[i], 0);
+		                  work.data.l[i] * Math.min(work.delta_y[i], 0);
 		    }
 
 		    // Check if the condition is satisfied: ineq_lhs < -eps
@@ -1432,7 +1432,7 @@ public class OSQP {
 			  // Reset solver information
 			  reset_info(work.info);
 			}
-		
+
 		
 		public void update_bounds(double[] l_new, double[] u_new) {
 			int i;

--- a/src/test/java/com/quantego/josqp/BasicQPTest.java
+++ b/src/test/java/com/quantego/josqp/BasicQPTest.java
@@ -547,6 +547,7 @@ public class BasicQPTest {
         // Define Solver settings as default
         final OSQP.Settings settings = new OSQP.Settings();
         settings.check_termination = 1;
+        settings.adaptive_rho = false; // this must be false to test cold start
 
         // Setup workspace
         final OSQP osqp = new OSQP(data, settings);
@@ -557,6 +558,7 @@ public class BasicQPTest {
 
         // Cold start and solve again
         osqp.warm_start(x0, y0);
+        settings.warm_start = false; // we need to set the warm_start to false after clearing variables
         osqp.solve();
 
         // Check if the number of iterations is the same

--- a/src/test/java/com/quantego/josqp/UnconstrainedTest.java
+++ b/src/test/java/com/quantego/josqp/UnconstrainedTest.java
@@ -30,8 +30,7 @@ public class UnconstrainedTest {
 
         // Compare primal solutions
         assertEquals("Unconstrained test solve: Error in primal solution!",
-                LinAlg.vec_norm_inf_diff(osqp.work.solution.x, sols_data.x_test, data.n),
-                OSQPTester.TESTS_TOL);
+                true,LinAlg.vec_norm_inf_diff(osqp.work.solution.x, sols_data.x_test, data.n)<OSQPTester.TESTS_TOL);
 
         // Compare objective values
         assertEquals("Unconstrained test solve: Error in objective value!",sols_data.obj_value_test, osqp.work.info.obj_val, OSQPTester.TESTS_TOL

--- a/src/test/java/com/quantego/josqp/UnconstrainedTestDataGenerator.java
+++ b/src/test/java/com/quantego/josqp/UnconstrainedTestDataGenerator.java
@@ -14,7 +14,7 @@ final class UnconstrainedTestDataGenerator {
         final int A_m = 0;
         final int A_n = 5;
         final int A_nzmax = 0;
-        final double[] A_x = null;
+        final double[] A_x = new double[0];
         final int[] A_i = null;
         final int[] A_p = new int[] { 0, 0, 0, 0, 0, 0, 0 };
         final CSCMatrix A = new CSCMatrix(A_m, A_n, A_nzmax, A_p, A_i, A_x);

--- a/src/test/java/com/quantego/josqp/UpdateMatricesTest.java
+++ b/src/test/java/com/quantego/josqp/UpdateMatricesTest.java
@@ -49,7 +49,7 @@ public class UpdateMatricesTest {
         final UpdateMatricesTestSolsData data = UpdateMatricesTestDataGenerator.generateData();
 
         // Generate first problem data
-        final OSQP.Data problem = new OSQP.Data(data.test_solve_Pu.n, data.test_solve_A.m,
+        OSQP.Data problem = new OSQP.Data(data.test_solve_Pu.n, data.test_solve_A.m,
                 data.test_solve_Pu, data.test_solve_A, data.test_solve_q, data.test_solve_l,
                 data.test_solve_u, 0);
 
@@ -99,15 +99,18 @@ public class UpdateMatricesTest {
 
         // Compare primal solutions
         assertEquals("Update matrices: problem with updating P, error in primal solution!",
-                LinAlg.vec_norm_inf_diff(osqp.work.solution.x, data.test_solve_P_new_x,
+                true,LinAlg.vec_norm_inf_diff(osqp.work.solution.x, data.test_solve_P_new_x,
                         data.n) < OSQPTester.TESTS_TOL);
 
         // Compare dual solutions
         assertEquals("Update matrices: problem with updating P, error in dual solution!",
-                LinAlg.vec_norm_inf_diff(osqp.work.solution.y, data.test_solve_P_new_y, data.m),
-                OSQPTester.TESTS_TOL,OSQPTester.TESTS_TOL);
+                true,LinAlg.vec_norm_inf_diff(osqp.work.solution.y, data.test_solve_P_new_y, data.m)<
+                OSQPTester.TESTS_TOL);
 
         // Cleanup and setup workspace
+        problem = new OSQP.Data(data.test_solve_Pu.n, data.test_solve_A.m,
+                data.test_solve_Pu, data.test_solve_A, data.test_solve_q, data.test_solve_l,
+                data.test_solve_u, 0);
         osqp = new OSQP(problem, settings);
 
         // Update P (all indices)
@@ -123,8 +126,8 @@ public class UpdateMatricesTest {
         // Compare primal solutions
         assertEquals(
                 "Update matrices: problem with updating P (all indices), error in primal solution!",
-                LinAlg.vec_norm_inf_diff(osqp.work.solution.x, data.test_solve_P_new_x, data.n),
-                OSQPTester.TESTS_TOL,OSQPTester.TESTS_TOL);
+                true,LinAlg.vec_norm_inf_diff(osqp.work.solution.x, data.test_solve_P_new_x, data.n)<
+                OSQPTester.TESTS_TOL);
 
         // Compare dual solutions
         assertEquals(
@@ -133,6 +136,9 @@ public class UpdateMatricesTest {
                 OSQPTester.TESTS_TOL,OSQPTester.TESTS_TOL);
 
         // Cleanup and setup workspace
+        problem = new OSQP.Data(data.test_solve_Pu.n, data.test_solve_A.m,
+                data.test_solve_Pu, data.test_solve_A, data.test_solve_q, data.test_solve_l,
+                data.test_solve_u, 0);
         osqp = new OSQP(problem, settings);
 
         // Update A
@@ -164,6 +170,9 @@ public class UpdateMatricesTest {
                 OSQPTester.TESTS_TOL,OSQPTester.TESTS_TOL);
 
         // Cleanup and setup workspace
+        problem = new OSQP.Data(data.test_solve_Pu.n, data.test_solve_A.m,
+                data.test_solve_Pu, data.test_solve_A, data.test_solve_q, data.test_solve_l,
+                data.test_solve_u, 0);
         osqp = new OSQP(problem, settings);
 
         // Update A (all indices)
@@ -189,6 +198,9 @@ public class UpdateMatricesTest {
                 OSQPTester.TESTS_TOL,OSQPTester.TESTS_TOL);
 
         // Cleanup and setup workspace
+        problem = new OSQP.Data(data.test_solve_Pu.n, data.test_solve_A.m,
+                data.test_solve_Pu, data.test_solve_A, data.test_solve_q, data.test_solve_l,
+                data.test_solve_u, 0);
         osqp = new OSQP(problem, settings);
 
         // Update P and A
@@ -213,6 +225,9 @@ public class UpdateMatricesTest {
                 OSQPTester.TESTS_TOL * OSQPTester.TESTS_TOL,OSQPTester.TESTS_TOL * OSQPTester.TESTS_TOL);
 
         // Cleanup and setup workspace
+        problem = new OSQP.Data(data.test_solve_Pu.n, data.test_solve_A.m,
+                data.test_solve_Pu, data.test_solve_A, data.test_solve_q, data.test_solve_l,
+                data.test_solve_u, 0);
         osqp = new OSQP(problem, settings);
 
         // Update P and A (all indices)


### PR DESCRIPTION
KKT.java contained a bug where the diagonal
pointers were thrown away when downsizing the
diagonal pointer array.

OSQP.java contained a bug where the prime
feasability test was incorrectly computing
ineq_lhs and therefore not returning true
for prime infeasilbility.

A number of test cases contained bugs. All of
the existing tests now pass.

There's a change to CSCMatrix.java to provide
a content replace method, that is unrelated to
the bug fixes.