### PR TITLE
Exclude JUnit from the josqp jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <version>${junit-jupiter.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.platform</groupId>


### PR DESCRIPTION
Correctly exclude JUnit from the josqp jar

Needed since we end up with something like this which conflicts with the JUnit version we're using

<img width="622" height="795" alt="image" src="https://github.com/user-attachments/assets/9ee80092-db94-48dd-904b-86d49cd9f765" />

This prevents that